### PR TITLE
Dockerfile con menos layers y un entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# MacOS
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,76 +1,38 @@
 FROM mediawiki:1.32.2
 
-RUN apt update && apt install -y unzip nano
+# Dependencias
+RUN apt-get update && apt-get install -y unzip librsvg2-bin && apt-get clean && pear install mail net_smtp
+
+# Composer
 RUN curl -S https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin –filename=composer
 
-####EXTENSIONES
+# Extensiones y customizaciones
 WORKDIR /var/www/html/extensions
-
-#VisualEditor extension
-RUN git clone --recurse-submodules -b REL1_32 https://gerrit.wikimedia.org/r/mediawiki/extensions/VisualEditor.git
-
-#TemplateStyles extension (para templates del editor)
-RUN curl -S https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/TemplateStyles/+archive/REL1_32.tar.gz | tar xz --one-top-level=TemplateStyles
-RUN cd TemplateStyles && php /usr/local/bin/composer.phar update --no-dev
-
-#PluggableAuth + OpenID extensions (para keycloack)
-RUN curl -S https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/PluggableAuth/+archive/REL1_32.tar.gz | tar xz --one-top-level=PluggableAuth
-RUN curl -S https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/OpenIDConnect/+archive/REL1_32.tar.gz | tar xz --one-top-level=OpenIDConnect
-RUN cd OpenIDConnect && php /usr/local/bin/composer.phar update --no-dev
-
-#Echo + Flow extensions (para las discusiones)
-RUN curl -S https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Echo/+archive/REL1_32.tar.gz | tar xz --one-top-level=Echo
-RUN cd Echo && php /usr/local/bin/composer.phar update --no-dev
-RUN curl -S https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Flow/+archive/REL1_32.tar.gz | tar xz --one-top-level=Flow
-RUN cd Flow && php /usr/local/bin/composer.phar update --no-dev
-
-#EditNotify
-RUN curl -S https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/EditNotify/+archive/REL1_32.tar.gz | tar xz --one-top-level=EditNotify
-RUN pear install mail net_smtp
-RUN cd EditNotify/i18n && cp en.json es.json && sed -i -e 's/was modified/tuvo modificaciones/' -e 's/was created/fue creada/' -e 's/Page/La página/' es.json
+RUN git clone --recurse-submodules -b REL1_32 https://gerrit.wikimedia.org/r/mediawiki/extensions/VisualEditor.git && \
+  curl -S https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/TemplateStyles/+archive/REL1_32.tar.gz | tar xz --one-top-level=TemplateStyles && \
+  cd TemplateStyles && php /usr/local/bin/composer.phar update --no-dev && cd .. && \
+  curl -S https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/PluggableAuth/+archive/REL1_32.tar.gz | tar xz --one-top-level=PluggableAuth && \
+  curl -S https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/OpenIDConnect/+archive/REL1_32.tar.gz | tar xz --one-top-level=OpenIDConnect && \
+  cd OpenIDConnect && php /usr/local/bin/composer.phar update --no-dev && cd .. && \
+  curl -S https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Echo/+archive/REL1_32.tar.gz | tar xz --one-top-level=Echo && \
+  cd Echo && php /usr/local/bin/composer.phar update --no-dev && cd .. && \
+  curl -S https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Flow/+archive/REL1_32.tar.gz | tar xz --one-top-level=Flow && \
+  cd Flow && php /usr/local/bin/composer.phar update --no-dev && cd .. && \
+  curl -S https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/EditNotify/+archive/REL1_32.tar.gz | tar xz --one-top-level=EditNotify && \
+  cd EditNotify/i18n && cp en.json es.json && sed -i -e 's/was modified/tuvo modificaciones/' -e 's/was created/fue creada/' -e 's/Page/La página/' es.json && \
+  echo ServerName web >> /etc/apache2/apache2.conf
 
 ####OTROS
 #Mobile skins
 #WORKDIR /var/www/html/skins
 #RUN git clone --recurse-submodules https://github.com/hutchy68/pivot.git
-#RUN echo '.oo-ui-tool .oo-ui-tool-link{ padding-top: 0em !important; }' >> pivot/assets/stylesheets/pivot.css 
+#RUN echo '.oo-ui-tool .oo-ui-tool-link{ padding-top: 0em !important; }' >> pivot/assets/stylesheets/pivot.css
 #RUN git clone --recurse-submodules --branch v2.2.0 https://github.com/thingles/foreground.git
 #RUN git clone --recurse-submodules --branch v1.1.0 https://github.com/thaider/Tweeki.git
 
-#SVG support
-RUN echo 'La siguiente operación puede tardar unos segundos' \
-	&& echo "El mensaje 'debconf: delaying package configuration...' es normal" \ 
-	&& apt install librsvg2-bin -y >/dev/null
-
-#Dejar en root para la shell
+# Dejar en root para la shell
 WORKDIR /var/www/html
-
-RUN echo ServerName web>> /etc/apache2/apache2.conf 
-
-COPY icons images/icons
+COPY icons /opt/icons
 COPY LocalSettings.php LocalSettingsINIT.php
-ENTRYPOINT if [ ! -f LocalSettings.php ]; then \
-		sleep 17; \
-		php maintenance/install.php \
-	        --confpath "/" \
-	        --dbserver "$MW_DB_SERVER" \
-	        --dbtype "$MW_DB_TYPE" \
-	        --dbname "$MW_DB_NAME" \
-	        --dbuser "$MW_DB_USER" \
-	        --dbpass "$MW_DB_PASSWORD" \
-	        --installdbuser "$MW_DB_INSTALLDB_USER" \
-	        --installdbpass "$MW_DB_INSTALLDB_PASS" \
-	        --server "$MW_SITE_SERVER" \
-	        --scriptpath "$MW_WEB_PATH" \
-	        --lang "$MW_SITE_LANG" \
-	        --pass "$MW_ADMIN_PASS" \
-	        "$MW_SITE_NAME" \
-	        "$MW_ADMIN_USER"; \
-		mv LocalSettingsINIT.php LocalSettings.php; \
-		php maintenance/update.php --quick; \
-		php maintenance/populateContentModel.php --wiki=somewiki --ns=1 --table=revision; \
-		php maintenance/populateContentModel.php --wiki=somewiki --ns=1 --table=archive; \
-		php maintenance/populateContentModel.php --wiki=somewiki --ns=1 --table=page; \
-		fi; \
-	exec apachectl -e info -D FOREGROUND
-
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Directorio de la instalacion
+cd /var/www/html
+
+# Verificar si esta es la primera vez que corre el container segun el nombre de LocalSettings.php.
+if [ ! -f LocalSettings.php ]
+then
+  php maintenance/install.php \
+    --confpath "/" \
+    --dbserver "$MW_DB_SERVER" \
+    --dbtype "$MW_DB_TYPE" \
+    --dbname "$MW_DB_NAME" \
+    --dbuser "$MW_DB_USER" \
+    --dbpass "$MW_DB_PASSWORD" \
+    --installdbuser "$MW_DB_INSTALLDB_USER" \
+    --installdbpass "$MW_DB_INSTALLDB_PASS" \
+    --server "$MW_SITE_SERVER" \
+    --scriptpath "$MW_WEB_PATH" \
+    --lang "$MW_SITE_LANG" \
+    --pass "$MW_ADMIN_PASS" \
+    "$MW_SITE_NAME" \
+    "$MW_ADMIN_USER"
+
+  mv LocalSettingsINIT.php LocalSettings.php
+  php maintenance/update.php --quick
+  php maintenance/populateContentModel.php --wiki=somewiki --ns=1 --table=revision
+  php maintenance/populateContentModel.php --wiki=somewiki --ns=1 --table=archive
+  php maintenance/populateContentModel.php --wiki=somewiki --ns=1 --table=page
+fi
+
+mv /opt/icons /var/www/html/images/icons
+chown -R www-data:www-data /var/www/html
+
+exec apachectl -e info -D FOREGROUND


### PR DESCRIPTION
Lo que hice en este Dockerfile son dos cosas:
1) Vas a ver que junté la instalación de dependencias por un lado y extensiones y customizaciones por otro. Esto lo hice para reducir la cantidad de layers de la imagen del container.

2) Definí un entry point para que no te quede todo ese código metido en el Dockerfile.

Qué es lo que falta?
1) Esto buildea ok pero necesito que valides contra una base de datos que estoy seguro tenes una a mano.
2) Fijate que en un punto del Dockerfile hice `COPY icons /opt/icons`, luego en el entrypoint paso ese directorio a `/var/www/html/images/icons`. Si queres hace lo mismo para las imágenes. La idea es mover eso dentro del entrypoint para poder montar el volumen sin problemas y no perder nada. 